### PR TITLE
Center align subtitle when long text is display

### DIFF
--- a/Sweet-Error/src/main/res/layout/layout_sweet_exception_handler.xml
+++ b/Sweet-Error/src/main/res/layout/layout_sweet_exception_handler.xml
@@ -134,6 +134,7 @@
             android:layout_width="wrap_content"
             android:textColor="@color/colorSweetError"
             android:textSize="@dimen/text_size_14sp"
+            android:gravity="center"
             tools:text="Top to add Deposit account"/>
 
     </LinearLayout>
@@ -172,6 +173,7 @@
             android:layout_width="wrap_content"
             android:textColor="@color/colorSweetError"
             android:textSize="@dimen/text_size_14sp"
+            android:gravity="center"
             tools:text="Top to add Deposit account"/>
 
     </LinearLayout>


### PR DESCRIPTION
![screenshot 1 1](https://user-images.githubusercontent.com/1019268/61947697-8b2d5c00-afc3-11e9-8ac5-fd0e4e9621c2.png)

As you see in screenshot long text default align by left, by setting internal gravity center. it showing much nice